### PR TITLE
add rasterization of pdf output

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,6 +29,9 @@ parser.add_argument('--dsa', type=float,
                     help='thickness of the sticky air')
 parser.add_argument('--shrinkcb', type=float,
                     help='color bar shrink')
+parser.add_argument('--pdf', action='store_true',
+                    help='produces non-rasterized, high quality \
+                    pdf (slow!)')
 parser.add_argument('--var', action='store_true',
                     help='display a list of available variables')
 

--- a/misc.py
+++ b/misc.py
@@ -9,6 +9,7 @@ def file_name(args, par_type):
 
     return args.name + '_' + par_type + '{:05d}'
 
+
 def path_fmt(args, par_type):
     """returns full path format for any time step"""
 
@@ -28,7 +29,7 @@ def lastfile(args, begstep):
 
     fmt = path_fmt(args, 't')
 
-    endstep = 99999
+    endstep = 100000
     while begstep + 1 < endstep:
         guess = int(ceil((endstep + begstep) / 2))
         if os.path.isfile(fmt.format(guess)):

--- a/stag.py
+++ b/stag.py
@@ -159,7 +159,7 @@ class StagyyData:
 
         fig, ax = plt.subplots(ncols=1, subplot_kw={'projection': 'polar'})
         if self.geom == 'annulus':
-            surf = ax.pcolormesh(xmesh, ymesh, fld)
+            surf = ax.pcolormesh(xmesh, ymesh, fld, rasterized=True)
             cbar = plt.colorbar(surf, shrink=self.args.shrinkcb)
             cbar.set_label(constants.varlist[var].name)
             plt.axis([self.rcmb, np.amax(xmesh), 0, np.amax(ymesh)])

--- a/stag.py
+++ b/stag.py
@@ -160,11 +160,10 @@ class StagyyData:
         fig, ax = plt.subplots(ncols=1, subplot_kw={'projection': 'polar'})
         if self.geom == 'annulus':
             surf = ax.pcolormesh(xmesh, ymesh, fld)
-            cbar = plt.colorbar(
-                surf, orientation='horizontal',
-                shrink=self.args.shrinkcb)
+            cbar = plt.colorbar(surf, shrink=self.args.shrinkcb)
             cbar.set_label(constants.varlist[var].name)
             plt.axis([self.rcmb, np.amax(xmesh), 0, np.amax(ymesh)])
 
+        plt.tight_layout()
         plt.savefig(misc.file_name(self.args, var).format(self.step) + '.pdf',
                     format='PDF')

--- a/stag.py
+++ b/stag.py
@@ -159,7 +159,8 @@ class StagyyData:
 
         fig, ax = plt.subplots(ncols=1, subplot_kw={'projection': 'polar'})
         if self.geom == 'annulus':
-            surf = ax.pcolormesh(xmesh, ymesh, fld, rasterized=True)
+            surf = ax.pcolormesh(xmesh, ymesh, fld,
+                                 rasterized=not self.args.pdf)
             cbar = plt.colorbar(surf, shrink=self.args.shrinkcb)
             cbar.set_label(constants.varlist[var].name)
             plt.axis([self.rcmb, np.amax(xmesh), 0, np.amax(ymesh)])


### PR DESCRIPTION
Modifications:

- fixes research of last file (problem when it was 99999);
- avoids annotation overlap in color bar;
- rasterization of pdf output file and creation of `--pdf` option to toggle it.